### PR TITLE
Fix assembly duplicities in metadata browser

### DIFF
--- a/src/Meditation.MetadataLoaderService/IMetadataLoader.cs
+++ b/src/Meditation.MetadataLoaderService/IMetadataLoader.cs
@@ -1,9 +1,11 @@
-﻿using Meditation.MetadataLoaderService.Models;
+﻿using System.Collections.Generic;
+using Meditation.MetadataLoaderService.Models;
 
 namespace Meditation.MetadataLoaderService
 {
     public interface IMetadataLoader
     {
+        IEnumerable<AssemblyMetadataEntry> LoadMetadataFromProcess(IEnumerable<string> modulePath);
         AssemblyMetadataEntry LoadMetadataFromAssembly(string path);
     }
 }

--- a/src/Meditation.MetadataLoaderService/Services/MetadataLoader.cs
+++ b/src/Meditation.MetadataLoaderService/Services/MetadataLoader.cs
@@ -24,21 +24,21 @@ namespace Meditation.MetadataLoaderService.Services
 
         public IEnumerable<AssemblyMetadataEntry> LoadMetadataFromProcess(IEnumerable<string> modulePaths)
         {
-            var assembliesLookup = new Dictionary<(UTF8String Name, Version Version), AssemblyDef>();
+            var assembliesLookup = new Dictionary<(UTF8String Name, Version Version, UTF8String Culture, PublicKey PublicKey), AssemblyDef>();
             foreach (var modulePath in modulePaths.OrderBy(Path.GetFileName))
             {
                 var (metadata, assemblyDef) = LoadMetadataFromAssemblyImpl(modulePath);
-                if (assembliesLookup.ContainsKey((assemblyDef.Name, assemblyDef.Version)))
+                if (assembliesLookup.ContainsKey((assemblyDef.Name, assemblyDef.Version, assemblyDef.Culture, assemblyDef.PublicKey)))
                 {
                     // This means that the assembly is already processed
                     // It happens usually in connection with NGEN (see: https://learn.microsoft.com/en-us/dotnet/framework/tools/ngen-exe-native-image-generator).
                     // For example, consider case when we are processing modules: System.Data.dll and subsequently try to process System.Data.ni.dll
 
-                    // FIXME: log reason for skipping assembly processing
+                    // FIXME [#16]: log reason for skipping assembly processing
                     continue;
                 }
 
-                assembliesLookup.Add((assemblyDef.Name, assemblyDef.Version), assemblyDef);
+                assembliesLookup.Add((assemblyDef.Name, assemblyDef.Version, assemblyDef.Culture, assemblyDef.PublicKey), assemblyDef);
                 yield return metadata;
             }
 

--- a/src/Meditation.UI/Services/AttachedProcessContext.cs
+++ b/src/Meditation.UI/Services/AttachedProcessContext.cs
@@ -4,6 +4,7 @@ using Meditation.MetadataLoaderService.Models;
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.IO;
 using System.Linq;
 using Meditation.AttachProcessService.Models;
 
@@ -58,20 +59,15 @@ namespace Meditation.UI.Services
         private void LoadAssemblies(IProcessSnapshot processSnapshot)
         {
             var builder = new List<AssemblyMetadataEntry>();
-            var modules = processSnapshot.GetModules();
-            foreach (var module in modules.Where(m => m.IsManaged).OrderBy(m => System.IO.Path.GetFileName(m.FileName)))
+            var managedModulePaths = processSnapshot.GetModules()
+                .Where(m => m.IsManaged)
+                .OrderBy(m => Path.GetFileName(m.FileName))
+                .Select(m => m.FileName);
+
+            foreach (var assemblyMetadata in _metadataLoader.LoadMetadataFromProcess(managedModulePaths))
             {
-                try
-                {
-                    var assemblyMetadata = _metadataLoader.LoadMetadataFromAssembly(module.FileName);
-                    AssemblyLoaded?.Invoke(processSnapshot.ProcessId, assemblyMetadata);
-                    builder.Add(assemblyMetadata);
-                }
-                catch (Exception)
-                {
-                    // FIXME: add logging
-                    throw;
-                }
+                AssemblyLoaded?.Invoke(processSnapshot.ProcessId, assemblyMetadata);
+                builder.Add(assemblyMetadata);
             }
 
             Assemblies = builder.ToImmutableArray();


### PR DESCRIPTION
This PR fixes an issue with assembly duplicities in metadata browser. We are filtering assemblies based on a 2-item key `(assemblyName, assemblyVersion)`. This filters situations such as loading `System.Data.dll` and `System.Data.ni.dll` and having almost identical entries in the metadata browser.

Please merge first #13 