### PR TITLE
Add assembly versions to metadata browser

### DIFF
--- a/src/Meditation.MetadataLoaderService/Models/AssemblyMetadataEntry.cs
+++ b/src/Meditation.MetadataLoaderService/Models/AssemblyMetadataEntry.cs
@@ -1,7 +1,8 @@
-﻿using System.Collections.Immutable;
+﻿using System;
+using System.Collections.Immutable;
 
 namespace Meditation.MetadataLoaderService.Models
 {
-    public record AssemblyMetadataEntry(string Name, AssemblyToken AssemblyToken, string FullName, ImmutableArray<MetadataEntryBase> Children)
+    public record AssemblyMetadataEntry(string Name, Version Version, AssemblyToken AssemblyToken, string FullName, ImmutableArray<MetadataEntryBase> Children)
         : MetadataEntryBase(Name, new MetadataToken(AssemblyToken.Value), Children);
 }

--- a/src/Meditation.MetadataLoaderService/Services/MetadataLoader.cs
+++ b/src/Meditation.MetadataLoaderService/Services/MetadataLoader.cs
@@ -72,7 +72,7 @@ namespace Meditation.MetadataLoaderService.Services
                 assemblyMembers.Add(new ModuleMetadataEntry(module.Name, moduleToken, module.Location, moduleMembers.ToImmutableArray()));
             }
             SortEntriesBy(assemblyMembers, m => m.Name);
-            return new AssemblyMetadataEntry(assembly.Name, assemblyToken, assembly.FullName, assemblyMembers.ToImmutableArray());
+            return new AssemblyMetadataEntry(assembly.Name, assembly.Version, assemblyToken, assembly.FullName, assemblyMembers.ToImmutableArray());
         }
 
         private static List<MetadataEntryBase> BuildModuleMembers(ModuleDef module)

--- a/src/Meditation.UI/Views/MetadataBrowserView.axaml
+++ b/src/Meditation.UI/Views/MetadataBrowserView.axaml
@@ -31,6 +31,7 @@
                     <StackPanel Orientation="Horizontal">
                         <Image Source="/Assets/Assembly.png" />
                         <TextBlock Text="{Binding Path=Name, StringFormat=' {0}'}" />
+                        <TextBlock Text="{Binding Path=Version, StringFormat=' ({0})'}" />
                     </StackPanel>
                 </TreeDataTemplate>
 


### PR DESCRIPTION
This PR adds assembly versions to metadata browser. So that it looks like this:
![image](https://github.com/DevToolsNET/meditation/assets/12575176/3e1e5b88-dbef-4ee3-a394-72c5393a7529)

It is a nice addition and also can be important to distinguish some assemblies. In some cases we might have multiple assemblies of different versions loaded in a process. This can be achieved using `extern alias` or just different `AppDomain`s or `AssemblyLoadContext`s.

Please merge first #14 