### PR TITLE
Fix crash on attach when no process selected

### DIFF
--- a/src/Meditation.UI/Controllers/AttachToProcessController.cs
+++ b/src/Meditation.UI/Controllers/AttachToProcessController.cs
@@ -61,7 +61,14 @@ namespace Meditation.UI.Controllers
         public async Task Attach(ProcessListViewModel processListViewModel, CancellationToken ct)
         {
             if (processListViewModel.SelectedProcess is not { } selectedProcessInfo)
-                throw new ArgumentException("No process was selected for attach", nameof(processListViewModel));
+            {
+                var messageBox = MessageBoxManager.GetMessageBoxStandard(
+                    title: "Nothing selected",
+                    text: "You need to select a process before proceeding.",
+                    @enum: ButtonEnum.Ok);
+                await messageBox.ShowAsync();
+                return;
+            }
 
             using var snapshot = await TryObtainProcessSnapshot(selectedProcessInfo, ct);
             if (snapshot == null)


### PR DESCRIPTION
This PR fixes an issue with propagating exception to user - causing a process crash. Instead we should show a message box and let user correct the mistake.