### PR TITLE
Fix crash when loading netmodules

### DIFF
--- a/src/Meditation.MetadataLoaderService/IMetadataLoader.cs
+++ b/src/Meditation.MetadataLoaderService/IMetadataLoader.cs
@@ -5,7 +5,7 @@ namespace Meditation.MetadataLoaderService
 {
     public interface IMetadataLoader
     {
-        IEnumerable<AssemblyMetadataEntry> LoadMetadataFromProcess(IEnumerable<string> modulePath);
-        AssemblyMetadataEntry LoadMetadataFromAssembly(string path);
+        IEnumerable<MetadataEntryBase> LoadMetadataFromProcess(IEnumerable<string> modulePaths);
+        MetadataEntryBase LoadMetadataFromPath(string path);
     }
 }

--- a/src/Meditation.UI/IAttachedProcessContext.cs
+++ b/src/Meditation.UI/IAttachedProcessContext.cs
@@ -11,10 +11,11 @@ namespace Meditation.UI
         event Action<ProcessId>? ProcessAttaching;
         event Action<ProcessId>? ProcessAttached;
         event Action<ProcessId>? ProcessDetached;
-        event Action<ProcessId, AssemblyMetadataEntry>? AssemblyLoaded;
+        event Action<ProcessId, MetadataEntryBase>? AssemblyOrNetModuleLoaded;
 
         IProcessSnapshot? ProcessSnapshot { get; }
         ImmutableArray<AssemblyMetadataEntry> Assemblies { get; }
+        ImmutableArray<ModuleMetadataEntry> NetModules { get; }
 
         void Initialize(IProcessSnapshot processSnapshot);
         void Reset();

--- a/src/Meditation.UI/ViewModels/MetadataBrowserViewModel.cs
+++ b/src/Meditation.UI/ViewModels/MetadataBrowserViewModel.cs
@@ -8,7 +8,7 @@ namespace Meditation.UI.ViewModels
 {
     public partial class MetadataBrowserViewModel : ViewModelBase
     {
-        [ObservableProperty] private FilterableObservableCollection<AssemblyMetadataEntry> _assemblies;
+        [ObservableProperty] private FilterableObservableCollection<MetadataEntryBase> _items;
         [ObservableProperty] private string? _metadataNameFilter;
         [ObservableProperty] private bool? _isLoadingData;
         private readonly IAttachedProcessContext _attachedProcessContext;
@@ -16,7 +16,7 @@ namespace Meditation.UI.ViewModels
         public MetadataBrowserViewModel(IAttachedProcessContext attachedProcessContext)
         {
             _attachedProcessContext = attachedProcessContext;
-            _assemblies = new FilterableObservableCollection<AssemblyMetadataEntry>(Enumerable.Empty<AssemblyMetadataEntry>());
+            _items = new FilterableObservableCollection<MetadataEntryBase>(Enumerable.Empty<MetadataEntryBase>());
             RegisterEventHandlers();
         }
 
@@ -29,17 +29,17 @@ namespace Meditation.UI.ViewModels
             _attachedProcessContext.ProcessAttached += _ => IsLoadingData = false;
 
             // Add assembly on process assembly loaded
-            _attachedProcessContext.AssemblyLoaded += (_, assembly) => Assemblies.Add(assembly);
+            _attachedProcessContext.AssemblyOrNetModuleLoaded += (_, metadata) => Items.Add(metadata);
 
             // Clear data on process detach
             _attachedProcessContext.ProcessDetached +=
-                _ => Assemblies = new FilterableObservableCollection<AssemblyMetadataEntry>(Enumerable.Empty<AssemblyMetadataEntry>());
+                _ => Items = new FilterableObservableCollection<MetadataEntryBase>(Enumerable.Empty<MetadataEntryBase>());
         }
 
         [RelayCommand]
         public void FilterMetadata()
         {
-            Assemblies.ApplyFilter(p => MetadataNameFilter == null || p.Name.Contains(MetadataNameFilter));
+            Items.ApplyFilter(p => MetadataNameFilter == null || p.Name.Contains(MetadataNameFilter));
         }
     }
 }

--- a/src/Meditation.UI/Views/MetadataBrowserView.axaml
+++ b/src/Meditation.UI/Views/MetadataBrowserView.axaml
@@ -24,7 +24,7 @@
         </Grid>
 
         <!-- Metadata browser -->
-        <TreeView IsEnabled="{Binding !IsLoadingData}" Grid.Row="1" ItemsSource="{Binding Assemblies.View}">
+        <TreeView IsEnabled="{Binding !IsLoadingData}" Grid.Row="1" ItemsSource="{Binding Items.View}">
             <TreeView.DataTemplates>
                 <!-- Assembly -->
                 <TreeDataTemplate ItemsSource="{Binding Children}" DataType="{x:Type models:AssemblyMetadataEntry}">

--- a/src/Tests/Meditation.MetadataLoaderService.Tests/MetadataLoaderTests.cs
+++ b/src/Tests/Meditation.MetadataLoaderService.Tests/MetadataLoaderTests.cs
@@ -17,7 +17,7 @@ namespace Meditation.MetadataLoaderService.Tests
             var loader = ServiceProvider.GetRequiredService<IMetadataLoader>();
 
             // Act
-            var assemblyMetadata = loader.LoadMetadataFromAssembly(assemblyLocation);
+            var assemblyMetadata = loader.LoadMetadataFromPath(assemblyLocation);
             var moduleMetadata = assemblyMetadata.Children.FirstOrDefault();
             var typeMetadata = moduleMetadata?.Children.FirstOrDefault(child => child is TypeMetadataEntry typeEntry && typeEntry.FullName == typeFullName);
             var methodMetadata = typeMetadata?.Children.FirstOrDefault(child => child is MethodMetadataEntry { Name: methodName });


### PR DESCRIPTION
This PR fixes a crash when loading stand-alone netmodules. Resolves #18.
Apparently, it is possible to have stand-alone netmodules that are not a part of any assembly. See this for more info: https://learn.microsoft.com/en-us/cpp/build/reference/noassembly-create-a-msil-module?view=msvc-170

In this case, the metadata browser looks like this:
![image](https://github.com/DevToolsNET/meditation/assets/12575176/b6af19cf-4e77-413d-a901-5dbda4ddeb16)
Note that `System.EnterpriseServices.Wrapper.dll` is a standalone netmodule. It is displayed at the top level of the treeview along with other assemblies (or possibly other netmodules).