### PR TITLE
Update deprecated GitHub actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,9 +6,9 @@ jobs:
   build-without-warnings:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Setup .NET
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 7.0.*
     - name: Restore dependencies
@@ -20,9 +20,9 @@ jobs:
   tests:
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Setup .NET
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 7.0.*
     - name: Restore dependencies


### PR DESCRIPTION
This PR fixes warnings on CI builds.

GitHub recently deprecated Node.js 16 actions:
![image](https://github.com/DevToolsNET/meditation/assets/12575176/bc06922e-8017-401e-8687-90d73accc882)
