### PR TITLE
Use only light theme

### DIFF
--- a/src/Meditation.UI/App.axaml
+++ b/src/Meditation.UI/App.axaml
@@ -1,7 +1,7 @@
 <Application xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              x:Class="Meditation.UI.App"
-             RequestedThemeVariant="Default">
+             RequestedThemeVariant="Light">
              <!-- "Default" ThemeVariant follows system theme variant. "Dark" or "Light" are other available options. -->
 
     <Application.Styles>


### PR DESCRIPTION
This PR changes makes it so that we do not inherit default system settings for choosing theme. We instead always use the light one.